### PR TITLE
Update Cancun

### DIFF
--- a/northamerica
+++ b/northamerica
@@ -2370,6 +2370,7 @@ Zone America/Cancun	-5:47:04 -	LMT	1922 Jan  1  0:12:56
 			-6:00	-	CST	1981 Dec 23
 			-5:00	Mexico	E%sT	1998 Aug  2  2:00
 			-6:00	Mexico	C%sT
+			-5:00   Mexico  E%sT    2015 Feb  1  0:01:35
 # Campeche, Yucatan
 Zone America/Merida	-5:58:28 -	LMT	1922 Jan  1  0:01:32
 			-6:00	-	CST	1981 Dec 23


### PR DESCRIPTION
Move Cancun, Quintana Roo to Easter Time Zone like Miami/New York.
